### PR TITLE
Add an incrementValue to Storage adapters

### DIFF
--- a/src/Flaps/Storage/DoctrineCacheAdapter.php
+++ b/src/Flaps/Storage/DoctrineCacheAdapter.php
@@ -42,6 +42,11 @@ class DoctrineCacheAdapter implements StorageInterface
         $this->cache->save($key, intval($value));
     }
 
+    public function incrementValue($key)
+    {
+        throw new \Exception('incrementValue() is not implemented for DoctrineCacheAdapter');
+    }
+
     public function getValue($key)
     {
         if (!$this->cache->contains($key)) {

--- a/src/Flaps/Storage/PredisStorage.php
+++ b/src/Flaps/Storage/PredisStorage.php
@@ -72,6 +72,11 @@ class PredisStorage implements StorageInterface
         $this->client->set($this->prefixKey($key), intval($value));
     }
 
+    public function incrementValue($key)
+    {
+        return intval($this->client->incr($this->prefixKey($key)));
+    }
+
     public function getValue($key)
     {
         return intval($this->client->get($this->prefixKey($key)));

--- a/src/Flaps/StorageInterface.php
+++ b/src/Flaps/StorageInterface.php
@@ -19,6 +19,14 @@ interface StorageInterface
     public function setValue($key, $value);
 
     /**
+     * Increments the number stored at $key by one.
+     * If the key does not exist, it is set to 0 before performing the operation.
+     * @param string $key the unique key to increment
+     * @return int the value associated with the key after the increment
+     */
+    public function incrementValue($key);
+
+    /**
      * Returns the value identified by $key in the storage backend.
      * @param string $key the unique key to return the value from
      * @return int the value associated with the key or 0, in none has been set

--- a/tests/Flaps/Mock/Storage.php
+++ b/tests/Flaps/Mock/Storage.php
@@ -22,6 +22,14 @@ class Storage implements StorageInterface
         $this->values[$key] = $value;
     }
 
+    public function incrementValue($key)
+    {
+        $value = $this->getValue($key) + 1;
+        $this->setValue($key, $value);
+
+        return $value;
+    }
+
     public function getValue($key)
     {
         return isset($this->values[$key]) ? $this->values[$key] : 0;

--- a/tests/Flaps/Storage/DoctrineCacheAdapterTest.php
+++ b/tests/Flaps/Storage/DoctrineCacheAdapterTest.php
@@ -46,6 +46,15 @@ class DoctrineCacheAdapterTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers BehEh\Flaps\Storage\DoctrineCacheAdapter::incrementValue
+     */
+    public function testIncrementValue()
+    {
+        $this->setExpectedExceptionRegExp('Exception', '/not implemented/');
+        $this->storage->incrementValue('key');
+    }
+
+    /**
      * @covers BehEh\Flaps\Storage\DoctrineCacheAdapter::setTimestamp
      * @covers BehEh\Flaps\Storage\DoctrineCacheAdapter::getTimestamp
      * @covers BehEh\Flaps\Storage\DoctrineCacheAdapter::expire

--- a/tests/Flaps/Storage/PredisStorageTest.php
+++ b/tests/Flaps/Storage/PredisStorageTest.php
@@ -28,6 +28,7 @@ class PredisStorageTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @covers BehEh\Flaps\Storage\PredisStorage::setValue
+     * @covers BehEh\Flaps\Storage\PredisStorage::incrementValue
      * @covers BehEh\Flaps\Storage\PredisStorage::getValue
      * @covers BehEh\Flaps\Storage\PredisStorage::expire
      */
@@ -39,6 +40,9 @@ class PredisStorageTest extends \PHPUnit_Framework_TestCase
         $this->storage->setValue('key', 1);
         $this->assertEquals(1, $this->client->exists('key'));
         $this->assertSame(1, $this->storage->getValue('key'));
+
+        $this->storage->incrementValue('key');
+        $this->assertSame(2, $this->storage->getValue('key'));
 
         $this->storage->setValue('key', 5);
         $this->assertSame(5, $this->storage->getValue('key'));


### PR DESCRIPTION
Fixes #5 

Please note this will require issuing a new version, `0.2.0`, since adding a method to an interface is a breaking change.

