### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"php": ">=5.3.0"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "~4.0",
+		"phpunit/phpunit": "~4.8.36",
 		"doctrine/cache": "~1.4",
 		"predis/predis": "~1.0"
 	},
@@ -27,6 +27,5 @@
 	},
 	"autoload": {
 		"psr-4": {"BehEh\\Flaps\\": "src/Flaps"}
-	}	
+	}
 }
-

--- a/tests/Flaps/FlapsTest.php
+++ b/tests/Flaps/FlapsTest.php
@@ -2,10 +2,11 @@
 
 namespace BehEh\Flaps;
 
+use PHPUnit\Framework\TestCase;
 use BehEh\Flaps\Mock\Storage as MockStorage;
 use BehEh\Flaps\Mock\ViolationHandler as MockViolationHandler;
 
-class FlapsTest extends \PHPUnit_Framework_TestCase
+class FlapsTest extends TestCase
 {
 
     /**

--- a/tests/Flaps/Storage/DoctrineCacheAdapterTest.php
+++ b/tests/Flaps/Storage/DoctrineCacheAdapterTest.php
@@ -2,10 +2,11 @@
 
 namespace BehEh\Flaps\Storage;
 
+use PHPUnit\Framework\TestCase;
 use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Cache\ArrayCache;
 
-class DoctrineCacheAdapterTest extends \PHPUnit_Framework_TestCase
+class DoctrineCacheAdapterTest extends TestCase
 {
 
     /**

--- a/tests/Flaps/Storage/PredisStorageTest.php
+++ b/tests/Flaps/Storage/PredisStorageTest.php
@@ -3,8 +3,9 @@
 namespace BehEh\Flaps\Storage;
 
 use Predis\Client;
+use PHPUnit\Framework\TestCase;
 
-class PredisStorageTest extends \PHPUnit_Framework_TestCase
+class PredisStorageTest extends TestCase
 {
 
     /**

--- a/tests/Flaps/Throttling/LeakyBucketStrategyTest.php
+++ b/tests/Flaps/Throttling/LeakyBucketStrategyTest.php
@@ -2,9 +2,10 @@
 
 namespace BehEh\Flaps\Throttling;
 
+use PHPUnit\Framework\TestCase;
 use BehEh\Flaps\Mock\Storage as MockStorage;
 
-class LeakyBucketStrategyTest extends \PHPUnit_Framework_TestCase
+class LeakyBucketStrategyTest extends TestCase
 {
 
     protected $strategy;

--- a/tests/Flaps/Throttling/ViolateAlwaysStrategyTest.php
+++ b/tests/Flaps/Throttling/ViolateAlwaysStrategyTest.php
@@ -2,7 +2,9 @@
 
 namespace BehEh\Flaps\Throttling;
 
-class ViolateAlwaysStrategyTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ViolateAlwaysStrategyTest extends TestCase
 {
 
     /**

--- a/tests/Flaps/Violation/ExceptionViolationHandlerTest.php
+++ b/tests/Flaps/Violation/ExceptionViolationHandlerTest.php
@@ -2,7 +2,9 @@
 
 namespace BehEh\Flaps\Violation;
 
-class ExceptionViolationHandlerTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ExceptionViolationHandlerTest extends TestCase
 {
 
     /**

--- a/tests/Flaps/Violation/HttpViolationHandlerTest.php
+++ b/tests/Flaps/Violation/HttpViolationHandlerTest.php
@@ -2,7 +2,9 @@
 
 namespace BehEh\Flaps\Violation;
 
-class HttpViolationHandlerTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class HttpViolationHandlerTest extends TestCase
 {
 
     /**

--- a/tests/Flaps/Violation/PassiveViolationHandlerTest.php
+++ b/tests/Flaps/Violation/PassiveViolationHandlerTest.php
@@ -2,7 +2,9 @@
 
 namespace BehEh\Flaps\Violation;
 
-class PassiveViolationHandlerTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class PassiveViolationHandlerTest extends TestCase
 {
 
     /**


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`~4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.